### PR TITLE
Add support for tagged instances

### DIFF
--- a/src/androidMain/kotlin/com/myunidays/segmenkt/Analytics.kt
+++ b/src/androidMain/kotlin/com/myunidays/segmenkt/Analytics.kt
@@ -15,6 +15,7 @@ actual class Analytics internal constructor(val android: com.segment.analytics.A
                 .experimentalUseNewLifecycleMethods(configuration.useLifecycleObserver)
                 .flushInterval(configuration.flushInterval.toLong(), TimeUnit.SECONDS)
                 .flushQueueSize(configuration.flushAt)
+                .tag(if (configuration.tag.isNullOrBlank()) configuration.writeKey else configuration.tag + "-" + configuration.writeKey)
             if (configuration.trackDeepLinks) analyticsConfig.trackDeepLinks()
             if (configuration.trackApplicationLifecycleEvents) analyticsConfig.trackApplicationLifecycleEvents()
             configuration.apiHost?.let { analyticsConfig.defaultApiHost(it) }

--- a/src/commonMain/kotlin/com.myunidays.segmenkt/Configuration.kt
+++ b/src/commonMain/kotlin/com.myunidays.segmenkt/Configuration.kt
@@ -18,6 +18,7 @@ package com.myunidays.segmenkt
 
 data class Configuration(
     val writeKey: String,
+    val tag: String? = null,
     val application: Any? = null,
 //    val storageProvider: StorageProvider,
     val collectDeviceId: Boolean = false,
@@ -31,5 +32,6 @@ data class Configuration(
     val apiHost: String? = null,
 //    val cdnHost: String? = null
 ) {
-    constructor(writeKey: WriteKey, context: Any? = null) : this(writeKey = writeKey.keyForPlatform(), application = context)
+    constructor(writeKey: WriteKey, tag: String?, context: Any? = null)
+            : this(writeKey = writeKey.keyForPlatform(), tag = tag, application = context)
 }


### PR DESCRIPTION
Added optional tag to configuration to support multiple analytics instances on Android (tag does not exist in iOS version of segment library).

Final tag includes the write key so its still clear for debugging.